### PR TITLE
Add a VPC endpoint for S3

### DIFF
--- a/infrastructure/modules/network/vpc_endpoints.tf
+++ b/infrastructure/modules/network/vpc_endpoints.tf
@@ -1,0 +1,9 @@
+data "aws_vpc_endpoint_service" "s3" {
+  service = "s3"
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id          = aws_vpc.vpc.id
+  service_name    = data.aws_vpc_endpoint_service.s3.service_name
+  route_table_ids = aws_route_table.private_route_table.*.id
+}


### PR DESCRIPTION
The lack of any VPC endpoints is a non-trivial cost – about $400 a month in managed NAT Gateway, and that was before anybody started using Archivematica for serious work.

This change adds an S3 VPC endpoint to the workflow and workflow-stage VPC, which should dramatically cut those costs.

I haven't set up other endpoints yet because I'm not sure what other services we're using; I'm guessing S3 is probably the bulk of the load.

For https://github.com/wellcomecollection/platform/issues/4325

### What is this PR trying to achieve?

Reduce the cost of running Goobi and Archivematica.

### Who is this change for?

For people who like money.
