### PR TITLE
Use efs provisioned throughput

### DIFF
--- a/infrastructure/modules/efs/main.tf
+++ b/infrastructure/modules/efs/main.tf
@@ -5,6 +5,9 @@ resource "aws_efs_file_system" "efs" {
   creation_token   = "${var.name}_efs"
   performance_mode = var.performance_mode
 
+  throughput_mode                 = var.throughput_mode
+  provisioned_throughput_in_mibps = var.provisioned_throughput_in_mibps
+
   tags = {
     Name        = var.name
     backup-plan = "workflow-default"

--- a/infrastructure/modules/efs/variables.tf
+++ b/infrastructure/modules/efs/variables.tf
@@ -25,3 +25,12 @@ variable "num_subnets" {
   description = "Number of subnets"
 }
 
+variable "throughput_mode" {
+  description = "EFS throughput mode (bursting or provisioned)"
+  default     = "bursting"
+}
+
+variable "provisioned_throughput_in_mibps" {
+  description = "EFS provisioned througput in MiB/s, if using provisioned throughput mode"
+  default     = null
+}

--- a/infrastructure/prod/efs.tf
+++ b/infrastructure/prod/efs.tf
@@ -3,6 +3,9 @@ module "efs" {
 
   name = "workflow"
 
+  throughput_mode = "provisioned"
+  provisioned_throughput_in_mibps = "10"
+
   vpc_id  = module.network.vpc_id
   subnets = module.network.private_subnets
 

--- a/infrastructure/prod/terraform.tf
+++ b/infrastructure/prod/terraform.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
   region = var.region
 
-  version = "~> 2.0"
+  version = "~> 2.70"
 }
 
 terraform {

--- a/infrastructure/staging/efs.tf
+++ b/infrastructure/staging/efs.tf
@@ -3,6 +3,9 @@ module "efs" {
 
   name = "workflow-stage"
 
+  throughput_mode = "provisioned"
+  provisioned_throughput_in_mibps = "5"
+
   vpc_id  = module.network.vpc_id
   subnets = module.network.private_subnets
 

--- a/infrastructure/staging/terraform.tf
+++ b/infrastructure/staging/terraform.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
   region = var.region
 
-  version = "~> 2.0"
+  version = "~> 2.70"
 }
 
 terraform {


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to achieve a better performance for shellserver jobs (especially BagIt creation) as well as Goobi, we switch EFS to  provisioned throughput mode.
With bursting mode throughput goes down quickly to the minimum when jobs are queuing up.

### Who is this change for?

For everyone wanting a half way decent throughput for conversion and bag jobs.
