### PR TITLE
Upgrade terraform to 0.13; add tags to the Goobi EC2 access hosts

### DIFF
--- a/infrastructure/modules/stack/goobi/main.tf
+++ b/infrastructure/modules/stack/goobi/main.tf
@@ -17,7 +17,7 @@ module "app_container_definition" {
       "awslogs-group"         = "ecs/${var.name}",
       "awslogs-region"        = "eu-west-1",
       "awslogs-create-group"  = "true",
-      "awslogs-stream-prefix" = "${var.name}"
+      "awslogs-stream-prefix" = var.name
     }
 
     secretOptions = null
@@ -63,7 +63,7 @@ module "proxy_container_definition" {
       "awslogs-group"         = "ecs/${var.name}",
       "awslogs-region"        = "eu-west-1",
       "awslogs-create-group"  = "true",
-      "awslogs-stream-prefix" = "${var.name}"
+      "awslogs-stream-prefix" = var.name
     }
 
     secretOptions = null

--- a/infrastructure/modules/stack/harvester/main.tf
+++ b/infrastructure/modules/stack/harvester/main.tf
@@ -16,7 +16,7 @@ module "app_container_definition" {
       "awslogs-group"         = "ecs/${var.name}",
       "awslogs-region"        = "eu-west-1",
       "awslogs-create-group"  = "true",
-      "awslogs-stream-prefix" = "${var.name}"
+      "awslogs-stream-prefix" = var.name
     }
 
     secretOptions = null
@@ -61,7 +61,7 @@ module "proxy_container_definition" {
       "awslogs-group"         = "ecs/${var.name}",
       "awslogs-region"        = "eu-west-1",
       "awslogs-create-group"  = "true",
-      "awslogs-stream-prefix" = "${var.name}"
+      "awslogs-stream-prefix" = var.name
     }
 
     secretOptions = null

--- a/infrastructure/modules/stack/itm/main.tf
+++ b/infrastructure/modules/stack/itm/main.tf
@@ -17,7 +17,7 @@ module "app_container_definition" {
       "awslogs-group"         = "ecs/${var.name}",
       "awslogs-region"        = "eu-west-1",
       "awslogs-create-group"  = "true",
-      "awslogs-stream-prefix" = "${var.name}"
+      "awslogs-stream-prefix" = var.name
     }
 
     secretOptions = null
@@ -63,7 +63,7 @@ module "proxy_container_definition" {
       "awslogs-group"         = "ecs/${var.name}",
       "awslogs-region"        = "eu-west-1",
       "awslogs-create-group"  = "true",
-      "awslogs-stream-prefix" = "${var.name}"
+      "awslogs-stream-prefix" = var.name
     }
 
     secretOptions = null

--- a/infrastructure/modules/stack/shell_server/main.tf
+++ b/infrastructure/modules/stack/shell_server/main.tf
@@ -16,7 +16,7 @@ module "container_definition" {
       "awslogs-group"         = "ecs/${var.name}",
       "awslogs-region"        = "eu-west-1",
       "awslogs-create-group"  = "true",
-      "awslogs-stream-prefix" = "${var.name}"
+      "awslogs-stream-prefix" = var.name
     }
 
     secretOptions = null

--- a/infrastructure/prod/ec2_host.tf
+++ b/infrastructure/prod/ec2_host.tf
@@ -10,6 +10,10 @@ resource "aws_instance" "access_host" {
   subnet_id                   = element(module.network.public_subnets, 0)
   associate_public_ip_address = true
   #   user_data = 
+	
+  tags = {
+    Name = "goobi-access-host"
+  }
 
   lifecycle {
     ignore_changes = [

--- a/infrastructure/prod/parameters.tf
+++ b/infrastructure/prod/parameters.tf
@@ -87,9 +87,9 @@ data "aws_ssm_parameter" "rds_password" {
 }
 
 locals {
-  admin_cidr_ingress                = "${split(",", data.aws_ssm_parameter.admin_cidr_ingress.value)}"
-  itm_source_ips                    = "${split(",", data.aws_ssm_parameter.itm_source_ips.value)}"
-  harvester_source_ips              = "${split(",", data.aws_ssm_parameter.harvester_source_ips.value)}"
+  admin_cidr_ingress                = split(",", data.aws_ssm_parameter.admin_cidr_ingress.value)
+  itm_source_ips                    = split(",", data.aws_ssm_parameter.itm_source_ips.value)
+  harvester_source_ips              = split(",", data.aws_ssm_parameter.harvester_source_ips.value)
   shell_server_container_image      = data.aws_ssm_parameter.shell_server_container_image.value
   goobi_container_image             = data.aws_ssm_parameter.goobi_container_image.value
   harvester_container_image         = data.aws_ssm_parameter.harvester_container_image.value

--- a/infrastructure/prod/versions.tf
+++ b/infrastructure/prod/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/infrastructure/staging/ec2_host.tf
+++ b/infrastructure/staging/ec2_host.tf
@@ -10,6 +10,10 @@ resource "aws_instance" "access_host" {
   subnet_id                   = element(module.network.public_subnets, 0)
   associate_public_ip_address = true
   #   user_data = 
+	
+  tags = {
+    Name = "goobi-access-host-staging"
+  }
 
   lifecycle {
     ignore_changes = [

--- a/infrastructure/staging/parameters.tf
+++ b/infrastructure/staging/parameters.tf
@@ -103,9 +103,9 @@ data "aws_ssm_parameter" "rds_password" {
 }
 
 locals {
-  admin_cidr_ingress                = "${split(",", data.aws_ssm_parameter.admin_cidr_ingress.value)}"
-  itm_source_ips                    = "${split(",", data.aws_ssm_parameter.itm_source_ips.value)}"
-  harvester_source_ips              = "${split(",", data.aws_ssm_parameter.harvester_source_ips.value)}"
+  admin_cidr_ingress                = split(",", data.aws_ssm_parameter.admin_cidr_ingress.value)
+  itm_source_ips                    = split(",", data.aws_ssm_parameter.itm_source_ips.value)
+  harvester_source_ips              = split(",", data.aws_ssm_parameter.harvester_source_ips.value)
   shell_server_container_image      = data.aws_ssm_parameter.shell_server_container_image.value
   goobi_container_image             = data.aws_ssm_parameter.goobi_container_image.value
   harvester_container_image         = data.aws_ssm_parameter.harvester_container_image.value

--- a/infrastructure/staging/versions.tf
+++ b/infrastructure/staging/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
The goal of this patch is to add names to the Goobi EC2 instances in the console, so it's obvious at a glance what they're for:

<img width="424" alt="Screenshot 2020-12-03 at 10 57 18" src="https://user-images.githubusercontent.com/301220/101000959-74532e00-3556-11eb-99ea-e14df1483c8c.png">

I also had to upgrade to Terraform 0.13 as that's the only version I have available. Not a significant change.