### PR TITLE
WIP: add second efs as working storage for workernodes

### DIFF
--- a/infrastructure/modules/stack/worker_node/main.tf
+++ b/infrastructure/modules/stack/worker_node/main.tf
@@ -10,6 +10,10 @@ module "container_definition" {
       sourceVolume  = "efs"
     },
     {
+      containerPath = "/workingstorage/"
+      sourceVolume  = "workingstorage-efs"
+    },
+    {
       containerPath = "/var/scratch"
       sourceVolume  = "scratch"
     }
@@ -56,7 +60,13 @@ module "task_definition" {
     name           = "efs"
     file_system_id = var.efs_id
     root_directory = "/"
-  }]
+  },
+  {
+    name           = "workingstorage-efs"
+    file_system_id = var.working_storage_efs_id
+    root_directory = "/"
+  }
+  ]
 
   volumes = [{
     name = "scratch"

--- a/infrastructure/modules/stack/worker_node/variables.tf
+++ b/infrastructure/modules/stack/worker_node/variables.tf
@@ -56,6 +56,10 @@ variable "efs_id" {
   type = string
 }
 
+variable "working_storage_efs_id" {
+  type = string
+}
+
 variable "cluster_arn" {
   type = string
 }

--- a/infrastructure/staging/efs.tf
+++ b/infrastructure/staging/efs.tf
@@ -13,3 +13,19 @@ module "efs" {
 
   efs_access_security_group_ids = [aws_security_group.efs.id]
 }
+
+module "efs-workernode" {
+  source = "../modules/efs"
+
+  name = "workflow-stage-workernode-storage"
+
+  throughput_mode                 = "provisioned"
+  provisioned_throughput_in_mibps = "5"
+
+  vpc_id  = module.network.vpc_id
+  subnets = module.network.private_subnets
+
+  num_subnets = length(module.network.private_subnets)
+
+  efs_access_security_group_ids = [aws_security_group.efs.id]
+}

--- a/infrastructure/staging/efs.tf
+++ b/infrastructure/staging/efs.tf
@@ -19,8 +19,7 @@ module "efs-workernode" {
 
   name = "workflow-stage-workernode-storage"
 
-  throughput_mode                 = "provisioned"
-  provisioned_throughput_in_mibps = "5"
+  throughput_mode = "bursting"
 
   vpc_id  = module.network.vpc_id
   subnets = module.network.private_subnets

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -197,7 +197,7 @@ module "worker_node_1" {
   cpu    = "2048"
   memory = "6144"
 
-  working_storage_path         = "/efs/tmp_workernode1"
+  working_storage_path         = "/workingstorage/tmp_workernode1"
   data_bucket_name             = aws_s3_bucket.workflow-stage-data.bucket
   configuration_bucket_name    = aws_s3_bucket.workflow-stage-configuration.bucket
   goobi_external_job_queue     = module.queues.queue_job_name
@@ -215,6 +215,7 @@ module "worker_node_1" {
   ]
 
   efs_id = module.efs.efs_id
+  working_storage_efs_id = module.efs-workernode.efs_id
 
   worker_node_container_image = local.worker_node_container_image
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to take load off the main efs holding the mets files, we create a second efs to create the bagit packages on. This way Goobi stays fast, even with a high throughput.

### Who is this change for?

For goobi users who like a fast and responsive system.

