### PR TITLE
Add some default tags to distinguish infrastructure

### DIFF
--- a/infrastructure/prod/ec2_host.tf
+++ b/infrastructure/prod/ec2_host.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "access_host" {
   subnet_id                   = element(module.network.public_subnets, 0)
   associate_public_ip_address = true
   #   user_data = 
-	
+
   tags = {
     Name = "goobi-access-host"
   }

--- a/infrastructure/prod/efs.tf
+++ b/infrastructure/prod/efs.tf
@@ -3,7 +3,7 @@ module "efs" {
 
   name = "workflow"
 
-  throughput_mode = "provisioned"
+  throughput_mode                 = "provisioned"
   provisioned_throughput_in_mibps = "10"
 
   vpc_id  = module.network.vpc_id

--- a/infrastructure/prod/provider.tf
+++ b/infrastructure/prod/provider.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  assume_role {
+    role_arn = "arn:aws:iam::299497370133:role/workflow-admin"
+  }
+
+  region = var.region
+
+  version = "~> 3.10"
+
+  default_tags {
+    tags = {
+      TerraformConfigurationURL = "https://github.com/wellcomecollection/goobi-infrastructure/tree/master/infrastructure/prod"
+      Environment               = "Production"
+      Department                = "Digital Production"
+      Division                  = "Culture and Society"
+      Use                       = "Goobi"
+    }
+  }
+}

--- a/infrastructure/prod/s3.tf
+++ b/infrastructure/prod/s3.tf
@@ -166,7 +166,7 @@ resource "aws_s3_bucket_notification" "bucket_notification_workflow-upload" {
     filter_prefix       = "video/"
     filter_suffix       = ".mpg"
   }
- lambda_function {
+  lambda_function {
     lambda_function_arn = aws_lambda_function.lambda_s3_trigger_goobi_video.arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "video/"

--- a/infrastructure/prod/terraform.tf
+++ b/infrastructure/prod/terraform.tf
@@ -1,23 +1,3 @@
-provider "aws" {
-  assume_role {
-    role_arn = "arn:aws:iam::299497370133:role/workflow-admin"
-  }
-
-  region = var.region
-
-  version = "~> 3.10"
-
-  default_tags {
-    tags = {
-      TerraformConfigurationURL = "https://github.com/wellcomecollection/goobi-infrastructure/tree/master/infrastructure/prod"
-      Environment               = "Production"
-      Department                = "Digital Production"
-      Division                  = "Culture and Society"
-      Use                       = "Goobi"
-    }
-  }
-}
-
 terraform {
   required_version = ">= 0.12"
 

--- a/infrastructure/prod/terraform.tf
+++ b/infrastructure/prod/terraform.tf
@@ -6,6 +6,16 @@ provider "aws" {
   region = var.region
 
   version = "~> 3.10"
+
+  default_tags {
+    tags = {
+      TerraformConfigurationURL = "https://github.com/wellcomecollection/goobi-infrastructure/tree/master/infrastructure/prod"
+      Environment               = "Production"
+      Department                = "Digital Production"
+      Division                  = "Culture and Society"
+      Use                       = "Goobi"
+    }
+  }
 }
 
 terraform {

--- a/infrastructure/staging/provider.tf
+++ b/infrastructure/staging/provider.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  assume_role {
+    role_arn = "arn:aws:iam::299497370133:role/workflow-admin"
+  }
+
+  region = var.region
+
+  version = "~> 3.10"
+
+  default_tags {
+    tags = {
+      TerraformConfigurationURL = "https://github.com/wellcomecollection/goobi-infrastructure/tree/master/infrastructure/staging"
+      Environment               = "Staging"
+      Department                = "Digital Production"
+      Division                  = "Culture and Society"
+      Use                       = "Goobi"
+    }
+  }
+}

--- a/infrastructure/staging/s3.tf
+++ b/infrastructure/staging/s3.tf
@@ -150,7 +150,7 @@ resource "aws_s3_bucket_notification" "bucket_notification_workflow-stage-upload
     filter_suffix       = ".mpg"
   }
 
-lambda_function {
+  lambda_function {
     lambda_function_arn = aws_lambda_function.lambda_s3_trigger_goobi_stage_video.arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = "video/"

--- a/infrastructure/staging/terraform.tf
+++ b/infrastructure/staging/terraform.tf
@@ -1,23 +1,3 @@
-provider "aws" {
-  assume_role {
-    role_arn = "arn:aws:iam::299497370133:role/workflow-admin"
-  }
-
-  region = var.region
-
-  version = "~> 3.10"
-
-  default_tags {
-    tags = {
-      TerraformConfigurationURL = "https://github.com/wellcomecollection/goobi-infrastructure/tree/master/infrastructure/prod"
-      Environment               = "Staging"
-      Department                = "Digital Production"
-      Division                  = "Culture and Society"
-      Use                       = "Goobi"
-    }
-  }
-}
-
 terraform {
   required_version = ">= 0.12"
 

--- a/infrastructure/staging/terraform.tf
+++ b/infrastructure/staging/terraform.tf
@@ -6,6 +6,16 @@ provider "aws" {
   region = var.region
 
   version = "~> 3.10"
+
+  default_tags {
+    tags = {
+      TerraformConfigurationURL = "https://github.com/wellcomecollection/goobi-infrastructure/tree/master/infrastructure/prod"
+      Environment               = "Staging"
+      Department                = "Digital Production"
+      Division                  = "Culture and Society"
+      Use                       = "Goobi"
+    }
+  }
 }
 
 terraform {


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to easily distinguish Goobi infrastructure in the workflow AWS this change adds [default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider).

### Who is this change for?

For folk who want to be able to identify infra spend by project and make it easier for devs to understand infra in AWS.

