### PR TITLE
Expire delete markers

### DIFF
--- a/infrastructure/prod/s3.tf
+++ b/infrastructure/prod/s3.tf
@@ -12,6 +12,10 @@ resource "aws_s3_bucket" "workflow-configuration" {
     noncurrent_version_expiration {
       days = 90
     }
+
+    expiration {
+      expired_object_delete_marker = true
+    }
   }
 
   lifecycle {
@@ -37,6 +41,9 @@ resource "aws_s3_bucket" "workflow-data" {
     noncurrent_version_expiration {
       days = 60
     }
+    expiration {
+      expired_object_delete_marker = true
+    }
   }
 }
 
@@ -57,6 +64,10 @@ resource "aws_s3_bucket" "workflow-infra" {
 
     noncurrent_version_expiration {
       days = 60
+    }
+
+    expiration {
+      expired_object_delete_marker = true
     }
   }
 }
@@ -101,6 +112,10 @@ resource "aws_s3_bucket" "workflow-harvesting-results" {
 
     noncurrent_version_expiration {
       days = 90
+    }
+
+    expiration {
+      expired_object_delete_marker = true
     }
   }
 }

--- a/infrastructure/staging/s3.tf
+++ b/infrastructure/staging/s3.tf
@@ -12,6 +12,10 @@ resource "aws_s3_bucket" "workflow-stage-configuration" {
     noncurrent_version_expiration {
       days = 90
     }
+
+    expiration {
+      expired_object_delete_marker = true
+    }
   }
 
   lifecycle {
@@ -36,6 +40,9 @@ resource "aws_s3_bucket" "workflow-stage-data" {
 
     noncurrent_version_expiration {
       days = 60
+    }
+    expiration {
+      expired_object_delete_marker = true
     }
   }
 }
@@ -84,6 +91,10 @@ resource "aws_s3_bucket" "workflow-stage-harvesting-results" {
 
     noncurrent_version_expiration {
       days = 90
+    }
+
+    expiration {
+      expired_object_delete_marker = true
     }
   }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to keep versioned S3 buckets clean, expired delete markers will be deleted in versioned buckets.