### PR TITLE
Workflow s3 lifecycle standard ia

### DIFF
--- a/infrastructure/modules/stack/harvester/listener_rule.tf
+++ b/infrastructure/modules/stack/harvester/listener_rule.tf
@@ -1,5 +1,5 @@
 resource "aws_alb_listener_rule" "https" {
-  for_each     = var.source_ips
+  for_each     = nonsensitive(var.source_ips)
   listener_arn = var.alb_listener_arn
 
   action {

--- a/infrastructure/modules/stack/itm/listener_rule.tf
+++ b/infrastructure/modules/stack/itm/listener_rule.tf
@@ -1,5 +1,5 @@
 resource "aws_alb_listener_rule" "https" {
-  for_each     = var.source_ips
+  for_each     = nonsensitive(var.source_ips)
   listener_arn = var.alb_listener_arn
 
   action {

--- a/infrastructure/prod/outputs.tf
+++ b/infrastructure/prod/outputs.tf
@@ -46,6 +46,7 @@ output "production_iha_id" {
 
 output "production_iha_secret" {
   value = module.production_iam.in_house_archives_secret
+  sensitive = true
 }
 
 output "production_ihp_id" {
@@ -54,6 +55,7 @@ output "production_ihp_id" {
 
 output "production_ihp_secret" {
   value = module.production_iam.in_house_photography_secret
+  sensitive = true
 }
 
 output "production_dis_id" {
@@ -62,4 +64,5 @@ output "production_dis_id" {
 
 output "production_dis_secret" {
   value = module.production_iam.digitisation_services_secret
+  sensitive = true
 }

--- a/infrastructure/prod/s3.tf
+++ b/infrastructure/prod/s3.tf
@@ -36,13 +36,28 @@ resource "aws_s3_bucket" "workflow-data" {
   }
 
   lifecycle_rule {
+    id      = "expire_noncurrent_versions"
     enabled = true
 
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
     noncurrent_version_expiration {
       days = 60
     }
     expiration {
       expired_object_delete_marker = true
+    }
+  }
+
+  lifecycle_rule {
+    id      = "transition_objects_to_standard_ia"
+    enabled = true
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
   }
 }

--- a/infrastructure/staging/s3.tf
+++ b/infrastructure/staging/s3.tf
@@ -36,13 +36,28 @@ resource "aws_s3_bucket" "workflow-stage-data" {
   }
 
   lifecycle_rule {
+    id      = "expire_noncurrent_versions"
     enabled = true
 
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
     noncurrent_version_expiration {
       days = 60
     }
     expiration {
       expired_object_delete_marker = true
+    }
+  }
+
+  lifecycle_rule {
+    id      = "transition_objects_to_standard_ia"
+    enabled = true
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
     }
   }
 }


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to reduce storage costs as described in #423 we add a lifecycle rule for older objects to move to standard_ia storage class after 30 days

