### PR TITLE
Use the Loris user-data for mounting EBS mounts

### DIFF
--- a/infrastructure/modules/ec2_capacity_provider/user_data.tpl
+++ b/infrastructure/modules/ec2_capacity_provider/user_data.tpl
@@ -4,25 +4,17 @@ MIME-Version: 1.0
 --==BOUNDARY==
 Content-Type: text/cloud-boothook; charset="us-ascii"
 
-# Install nfs-utils.
-# Maybe needed to get ecs.capability.secrets.ssm.environment-variables???
-cloud-init-per once yum_update yum update -y
-
 # Create /ebs folder
 cloud-init-per once mkdir_ebs mkdir -p ${ebs_host_path}
 
-# Format the EBS volume as ext4.  We only want to do this if the volume
-# hasn't already been formatted by another EC2 instance.
-#
-# See https://serverfault.com/a/975257/206273
-#echo "blkid --match-token TYPE=ext4 ${ebs_volume_id} || mkfs --type ext4 ${ebs_volume_id}" >> format_ebs_volume.sh
-cloud-init-per once format_ebs mkfs --type ext4 ${ebs_volume_id}
+# Format ebs volume
+cloud-init-per once format_ebs mkfs -t ext4 ${ebs_volume_id}
 
 # Add /ebs to fstab
 cloud-init-per once mount_ebs echo -e '${ebs_volume_id} ${ebs_host_path} ext4 defaults,nofail 0 2' >> /etc/fstab
 
 # Mount all
-mount --all
+mount -a
 
 --==BOUNDARY==
 Content-Type: text/x-shellscript; charset="us-ascii"
@@ -32,6 +24,7 @@ Content-Type: text/x-shellscript; charset="us-ascii"
 cat << EOF > /etc/ecs/ecs.config
 
 ECS_CLUSTER=${cluster_name}
+ECS_INSTANCE_ATTRIBUTES={"ebs.volume":"${ebs_volume_id}"}
 
 EOF
 --==BOUNDARY==--


### PR DESCRIPTION
This seems to resolve an issue we were having where EC2 instances would start but not register as ECS container hosts.  I don't understand what the issue with the old user-data was and I don't have time to debug it properly, but this seems to fix the issue.