### PR TITLE
WIP: SNS topic for dds notification

### DIFF
--- a/infrastructure/modules/stack/goobi/main.tf
+++ b/infrastructure/modules/stack/goobi/main.tf
@@ -44,6 +44,7 @@ module "app_container_definition" {
     GOOBI_EXTERNAL_COMMAND_QUEUE = var.goobi_external_command_queue
     GOOBI_EXTERNAL_JOB_DLQ       = var.goobi_external_job_dlq
     bagitqueue                   = var.goobi_external_bagit_job_queue
+    SNS_DDS_TOPIC                = var.sns_topic_output_notification
   }
 
   secrets = local.secrets

--- a/infrastructure/modules/stack/goobi/variables.tf
+++ b/infrastructure/modules/stack/goobi/variables.tf
@@ -125,3 +125,8 @@ variable "goobi_external_bagit_job_queue" {
   type    = string
   default = null
 }
+
+variable "sns_topic_output_notification" {
+  type    = string
+  default = null
+}

--- a/infrastructure/staging/iam_role_policy.tf
+++ b/infrastructure/staging/iam_role_policy.tf
@@ -44,6 +44,12 @@ resource "aws_iam_role_policy" "ecs_goobi_s3_allow_storage_archive_access" {
   policy = data.aws_iam_policy_document.allow_storage_archive_access.json
 }
 
+# allow goobi task to publish to SNS topic for output notification
+resource "aws_iam_role_policy" "ecs_goobi_sns_output_notification_allow_publish" {
+  role   = module.goobi.task_role
+  policy = module.sns_topic_output_notification.publish_policy
+}
+
 resource "aws_iam_role_policy" "ecs_itm_s3_config_read" {
   role   = module.itm.task_role
   policy = data.aws_iam_policy_document.s3_read_workflow-configuration.json

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -123,6 +123,7 @@ module "goobi" {
   goobi_external_command_queue   = module.queues.queue_command_name
   goobi_external_job_dlq         = module.queues.dlq_job_name
   goobi_external_bagit_job_queue = module.queues.queue_bagit_job_name
+  sns_topic_output_notification  = module.sns_topic_output_notification.arn
 
   cluster_arn = aws_ecs_cluster.cluster.arn
 
@@ -312,3 +313,9 @@ resource "aws_cloudwatch_log_group" "cloudwatch_log_group_workernode_bagit_stage
   retention_in_days = "14"
 }
 
+# SNS topic for DDS notification
+module "sns_topic_output_notification" {
+  source = "github.com/wellcomecollection/terraform-aws-sns-topic.git?ref=v1.0.1"
+  name   = "digitised-bag-notifications-workflow-staging"
+  # TODO add cross account subscription ids
+}


### PR DESCRIPTION
### What is this PR trying to achieve?

In order to switch from the DDS API call (formerly known as the PDF creation step) to the new SNS based notification (#437), this PR introduces the topic, needed permissions etc.
