### PR TITLE
Specify the base AMI for the container host & bastion by data block

### DIFF
--- a/infrastructure/staging/ec2_host.tf
+++ b/infrastructure/staging/ec2_host.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "access_host" {
-  ami           = data.aws_ami.amazon-linux-2.id
+  ami           = local.bastion_host_ami_id
   instance_type = var.access_host_instance_type
   key_name      = var.access_host_key_name
   vpc_security_group_ids = [
@@ -57,17 +57,6 @@ resource "aws_security_group" "access_host_full_egress" {
     create_before_destroy = true
   }
 }
-
-data "aws_ami" "amazon-linux-2" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn2-ami-hvm*"]
-  }
-}
-
 
 resource "random_id" "sg_append" {
   keepers = {

--- a/infrastructure/staging/efs.tf
+++ b/infrastructure/staging/efs.tf
@@ -19,7 +19,7 @@ module "efs-workernode" {
 
   name = "workflow-stage-workernode-storage"
 
-  throughput_mode = "provisioned"
+  throughput_mode                 = "provisioned"
   provisioned_throughput_in_mibps = "20"
 
   vpc_id  = module.network.vpc_id

--- a/infrastructure/staging/locals.tf
+++ b/infrastructure/staging/locals.tf
@@ -5,4 +5,26 @@ locals {
   ia_username_key     = "workflow/ia_username"
   ia_password_key     = "workflow/ia_password"
   account_id_digirati = "653428163053"
+
+  # The following are the AMI IDs for the latest Amazon Linux 2 ECS-optimised AMI
+  container_host_ami_id = data.aws_ami.container_host_ami.image_id
+  bastion_host_ami_id   = data.aws_ami.bastion_host_ami.image_id
+}
+
+data "aws_ami" "container_host_ami" {
+  most_recent = true
+  owners      = ["self"]
+  filter {
+    name   = "name"
+    values = ["weco-amzn2-ecs-optimised-hvm-x86_64*"]
+  }
+}
+
+data "aws_ami" "bastion_host_ami" {
+  most_recent = true
+  owners      = ["self"]
+  filter {
+    name   = "name"
+    values = ["weco-amzn2-hvm-x86_64*"]
+  }
 }

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -229,7 +229,7 @@ module "ec2_cluster_capacity_provider" {
   // The cluster name is required for the instance user data script
   // This is a known issue https://github.com/terraform-providers/terraform-provider-aws/issues/12739
   cluster_name = "${local.environment_name}_ec2"
-  ami_id = data.aws_ami.container_host_ami.image_id
+  ami_id       = data.aws_ami.container_host_ami.image_id
 
   instance_type           = "t3.medium"
   max_instances           = 2

--- a/infrastructure/staging/main.tf
+++ b/infrastructure/staging/main.tf
@@ -229,6 +229,7 @@ module "ec2_cluster_capacity_provider" {
   // The cluster name is required for the instance user data script
   // This is a known issue https://github.com/terraform-providers/terraform-provider-aws/issues/12739
   cluster_name = "${local.environment_name}_ec2"
+  ami_id = data.aws_ami.container_host_ami.image_id
 
   instance_type           = "t3.medium"
   max_instances           = 2

--- a/infrastructure/staging/rds.tf
+++ b/infrastructure/staging/rds.tf
@@ -10,7 +10,7 @@ module "goobi_rds_cluster_aurora3" {
   backup_retention_period = "14"
   deletion_protection     = "true"
   engine                  = "aurora-mysql"
-  engine_version          = "8.0.mysql_aurora.3.02.2"
+  engine_version          = "8.0.mysql_aurora.3.04.1"
 
   # The database is in a private subnet, so this CIDR only gives access to
   # other instances in the private subnet (in order to reach via bastion host)

--- a/infrastructure/staging/s3.tf
+++ b/infrastructure/staging/s3.tf
@@ -119,7 +119,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "workflow-stage-harvesting-resu
   bucket = aws_s3_bucket.workflow-stage-harvesting-results.id
 
   rule {
-    id = "expiration"
+    id     = "expiration"
     status = "Enabled"
     noncurrent_version_expiration {
       noncurrent_days = 90

--- a/infrastructure/staging/versions.tf
+++ b/infrastructure/staging/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = "~> 4.54"
     }
     random = {


### PR DESCRIPTION
## What does this change?

In order to use updated base AMIs with standard security requirements baked in, we use the AMIs built and distributed by the platform account.

This change follows:
- https://github.com/wellcomecollection/aws-account-infrastructure/pull/17
- https://github.com/wellcomecollection/platform-infrastructure/pull/416

### terraform plan
```console
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.ec2_cluster_capacity_provider.aws_autoscaling_group.asg will be updated in-place
  ~ resource "aws_autoscaling_group" "asg" {
        id                        = "workflow-stage_ec2_cluster_asg"
        name                      = "workflow-stage_ec2_cluster_asg"
        # (25 unchanged attributes hidden)

      ~ launch_template {
            id      = "lt-0fc1fcede19fc7081"
            name    = "workflow-stage_ec2_cluster_launch_template"
          ~ version = "37" -> (known after apply)
        }

        # (2 unchanged blocks hidden)
    }

  # module.ec2_cluster_capacity_provider.aws_launch_template.launch_template will be updated in-place
  ~ resource "aws_launch_template" "launch_template" {
      ~ default_version         = 37 -> (known after apply)
        id                      = "lt-0fc1fcede19fc7081"
      ~ image_id                = "ami-0914bb48d354dd0c7" -> "ami-0badf788590737070"
      ~ latest_version          = 37 -> (known after apply)
        name                    = "workflow-stage_ec2_cluster_launch_template"
        tags                    = {}
        # (10 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

  # module.worker_node_1.module.autoscaling.aws_appautoscaling_target.service_scale_target will be updated in-place
  ~ resource "aws_appautoscaling_target" "service_scale_target" {
        id                 = "service/workflow-stage/workflow-stage-workernode_1"
        tags               = {}
      ~ tags_all           = {
          + "Department"                = "Digital Production"
          + "Division"                  = "Culture and Society"
          + "Environment"               = "Staging"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/goobi-infrastructure/tree/master/infrastructure/staging"
          + "Use"                       = "Goobi"
        }
        # (6 unchanged attributes hidden)
    }

  # module.worker_node_bagit.module.autoscaling.aws_appautoscaling_target.service_scale_target will be updated in-place
  ~ resource "aws_appautoscaling_target" "service_scale_target" {
        id                 = "service/workflow-stage_ec2/workflow-stage-workernode_bagit"
        tags               = {}
      ~ tags_all           = {
          + "Department"                = "Digital Production"
          + "Division"                  = "Culture and Society"
          + "Environment"               = "Staging"
          + "TerraformConfigurationURL" = "https://github.com/wellcomecollection/goobi-infrastructure/tree/master/infrastructure/staging"
          + "Use"                       = "Goobi"
        }
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 4 to change, 0 to destroy.
```


## How to test

- [x] Apply the terraform, does it go out successfully? 
- [x] Does Goobi still behave as expected?
- [x] Are the appropriate agents running on the EC2 host

## How can we measure success?

The EC2 instances are properly monitored and we have a mechanism for keeping their base AMIs up to date.