### PR TITLE
Mg/remove itm prod

### DIFF
--- a/infrastructure/prod/iam_role_policy.tf
+++ b/infrastructure/prod/iam_role_policy.tf
@@ -45,21 +45,6 @@ resource "aws_iam_role_policy" "ecs_goobi_sns_output_notification_allow_publish"
   policy = module.sns_topic_output_notification.publish_policy
 }
 
-resource "aws_iam_role_policy" "ecs_itm_s3_config_read" {
-  role   = module.itm.task_role
-  policy = data.aws_iam_policy_document.s3_read_workflow-configuration.json
-}
-
-resource "aws_iam_role_policy" "ecs_itm_s3_data_rw" {
-  role   = module.itm.task_role
-  policy = data.aws_iam_policy_document.s3_rw_workflow-data.json
-}
-
-resource "aws_iam_role_policy" "ecs_itm_s3_editorial_photography_upload_external" {
-  role   = module.itm.task_role
-  policy = data.aws_iam_policy_document.s3_editorial_photography_upload_external.json
-}
-
 resource "aws_iam_role_policy" "ecs_harvester_s3_config_read" {
   role   = module.harvester.task_role
   policy = data.aws_iam_policy_document.s3_read_workflow-configuration.json

--- a/infrastructure/prod/main.tf
+++ b/infrastructure/prod/main.tf
@@ -71,50 +71,6 @@ module "harvester" {
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
 }
 
-module "itm" {
-  source = "../modules/stack/itm"
-
-  name = "${local.environment_name}-itm"
-
-  data_bucket_name          = aws_s3_bucket.workflow-data.bucket
-  configuration_bucket_name = aws_s3_bucket.workflow-configuration.bucket
-
-  cpu    = "1024"
-  memory = "4096"
-
-  cluster_arn = aws_ecs_cluster.cluster.arn
-
-  subnets = module.network.private_subnets
-
-  security_group_ids = [
-    aws_security_group.service_egress.id,
-    aws_security_group.interservice.id,
-    aws_security_group.efs.id,
-    aws_security_group.service_lb.id
-  ]
-
-  efs_id = module.efs.efs_id
-
-  itm_container_image   = local.itm_container_image
-  proxy_container_image = local.proxy_container_image
-
-  db_server       = module.goobi_rds_cluster_aurora3.host
-  db_port         = module.goobi_rds_cluster_aurora3.port
-  db_name         = "itm"
-  db_user_key     = local.db_user_key
-  db_password_key = local.db_password_key
-
-  host_name    = var.domain_name
-  path_pattern = "/itm/*"
-  source_ips   = local.itm_source_ips
-
-  vpc_id = module.network.vpc_id
-
-  alb_listener_arn = module.load_balancer.https_listener_arn
-
-  service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-}
-
 module "goobi" {
   source = "../modules/stack/goobi"
 

--- a/infrastructure/prod/parameters.tf
+++ b/infrastructure/prod/parameters.tf
@@ -2,10 +2,6 @@ data "aws_ssm_parameter" "admin_cidr_ingress" {
   name = "/workflow/config/prod/admin_cidr_ingress"
 }
 
-data "aws_ssm_parameter" "itm_source_ips" {
-  name = "/workflow/config/prod/itm_source_ips"
-}
-
 data "aws_ssm_parameter" "harvester_source_ips" {
   name = "/workflow/config/prod/harvester_source_ips"
 }
@@ -16,10 +12,6 @@ data "aws_ssm_parameter" "goobi_container_image" {
 
 data "aws_ssm_parameter" "harvester_container_image" {
   name = "/workflow/images/prod/harvester"
-}
-
-data "aws_ssm_parameter" "itm_container_image" {
-  name = "/workflow/images/prod/itm"
 }
 
 data "aws_ssm_parameter" "proxy_container_image" {
@@ -104,11 +96,9 @@ data "aws_ssm_parameter" "rds_password" {
 
 locals {
   admin_cidr_ingress                = split(",", data.aws_ssm_parameter.admin_cidr_ingress.value)
-  itm_source_ips                    = split(",", data.aws_ssm_parameter.itm_source_ips.value)
   harvester_source_ips              = split(",", data.aws_ssm_parameter.harvester_source_ips.value)
   goobi_container_image             = data.aws_ssm_parameter.goobi_container_image.value
   harvester_container_image         = data.aws_ssm_parameter.harvester_container_image.value
-  itm_container_image               = data.aws_ssm_parameter.itm_container_image.value
   proxy_container_image             = data.aws_ssm_parameter.proxy_container_image.value
   worker_node_container_image       = data.aws_ssm_parameter.worker_node_container_image.value
   lambda_api_endpoint_ep            = data.aws_ssm_parameter.lambda_api_endpoint_ep.value

--- a/infrastructure/staging/parameters.tf
+++ b/infrastructure/staging/parameters.tf
@@ -2,10 +2,6 @@ data "aws_ssm_parameter" "admin_cidr_ingress" {
   name = "/workflow/config/stage/admin_cidr_ingress"
 }
 
-data "aws_ssm_parameter" "itm_source_ips" {
-  name = "/workflow/config/stage/itm_source_ips"
-}
-
 data "aws_ssm_parameter" "harvester_source_ips" {
   name = "/workflow/config/stage/harvester_source_ips"
 }
@@ -20,10 +16,6 @@ data "aws_ssm_parameter" "goobi_container_image" {
 
 data "aws_ssm_parameter" "harvester_container_image" {
   name = "/workflow/images/stage/harvester"
-}
-
-data "aws_ssm_parameter" "itm_container_image" {
-  name = "/workflow/images/stage/itm"
 }
 
 data "aws_ssm_parameter" "proxy_container_image" {
@@ -104,12 +96,10 @@ data "aws_ssm_parameter" "rds_password" {
 
 locals {
   admin_cidr_ingress                = split(",", data.aws_ssm_parameter.admin_cidr_ingress.value)
-  itm_source_ips                    = split(",", data.aws_ssm_parameter.itm_source_ips.value)
   harvester_source_ips              = split(",", data.aws_ssm_parameter.harvester_source_ips.value)
   worker_node_container_image       = data.aws_ssm_parameter.worker_node_container_image.value
   goobi_container_image             = data.aws_ssm_parameter.goobi_container_image.value
   harvester_container_image         = data.aws_ssm_parameter.harvester_container_image.value
-  itm_container_image               = data.aws_ssm_parameter.itm_container_image.value
   proxy_container_image             = data.aws_ssm_parameter.proxy_container_image.value
   lambda_api_endpoint_ep            = data.aws_ssm_parameter.lambda_api_endpoint_ep.value
   lambda_templateid_ep              = data.aws_ssm_parameter.lambda_templateid_ep.value


### PR DESCRIPTION
### What is this PR trying to achieve?

This is following up on #457 and applying the same to production.

As we have migrated all jobs to worker nodes, there is no need to keep the ITM running anymore.
This PR is therefore remove ITM resources from production and removes remaining data/locals from staging as well.
