### PR TITLE
workernode: increase Java max heap memory allocation

### DIFF
--- a/infrastructure/modules/stack/worker_node/main.tf
+++ b/infrastructure/modules/stack/worker_node/main.tf
@@ -46,6 +46,7 @@ module "container_definition" {
     DB_SERVER                    = var.db_server
     DB_PORT                      = var.db_port
     DB_NAME                      = var.db_name
+    JAVA_TOOL_OPTIONS            = "-Xmx${var.memory * 0.5}m"
   }
 
   secrets = local.secrets


### PR DESCRIPTION
Set a -Xmx to half of the available memory for all Java processes via an environment variable.

### What is this PR trying to achieve?

In order to allow usage of more heap memory without increasing the available total memory, we adjust the max heap usage to half of the available memory.

(currently deployed on stage)