### PR TITLE
fix: glacier restore privileges for worker nodes missing

### DIFF
--- a/infrastructure/prod/iam_role_policy.tf
+++ b/infrastructure/prod/iam_role_policy.tf
@@ -93,6 +93,11 @@ resource "aws_iam_role_policy" "ecs_worker_node_1_read_write_queue" {
   policy = module.queues.read_write_policy
 }
 
+resource "aws_iam_role_policy" "ecs_worker_node_1_goobi_s3_editorial_photography_allow_restore" {
+  role   = module.worker_node_1.task_role
+  policy = data.aws_iam_policy_document.s3_editorial_photography_allow_restore.json
+}
+
 # worker node bagit
 resource "aws_iam_role_policy" "ecs_worker_node_bagit_read_write_queue" {
   role   = module.worker_node_bagit.task_role

--- a/infrastructure/staging/iam_role_policy.tf
+++ b/infrastructure/staging/iam_role_policy.tf
@@ -91,6 +91,11 @@ resource "aws_iam_role_policy" "ecs_worker_node_1_read_write_queue" {
   policy = module.queues.read_write_policy
 }
 
+resource "aws_iam_role_policy" "ecs_worker_node_1_goobi_s3_editorial_photography_allow_restore" {
+  role   = module.worker_node_1.task_role
+  policy = data.aws_iam_policy_document.s3_editorial_photography_allow_restore.json
+}
+
 # worker node bagit
 resource "aws_iam_role_policy" "ecs_worker_node_bagit_read_write_queue" {
   role   = module.worker_node_bagit.task_role


### PR DESCRIPTION
Restore permissions are necessary to update older EP data that has been moved to glacier

### What is this PR trying to achieve?

In order to ... 

### Who is this change for?

For `PERSON_WHO_CARES_ABOUT_THIS_CHANGE`

