### PR TITLE
Adds AmazonSSMManagedInstanceCore to instance profiles

### DIFF
--- a/infrastructure/modules/ec2_capacity_provider/iam.tf
+++ b/infrastructure/modules/ec2_capacity_provider/iam.tf
@@ -3,6 +3,11 @@ resource "aws_iam_instance_profile" "instance_profile" {
   role = aws_iam_role.instance_role.name
 }
 
+resource "aws_iam_role_policy_attachment" "ssm_managed_instance_core" {
+  role       = aws_iam_role.instance_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 data "aws_iam_policy_document" "assume_ec2_role" {
   statement {
     actions = [

--- a/infrastructure/prod/ec2_host.tf
+++ b/infrastructure/prod/ec2_host.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "access_host" {
   ]
   subnet_id                   = element(module.network.public_subnets, 0)
   associate_public_ip_address = true
-  #   user_data = 
+  iam_instance_profile        = aws_iam_instance_profile.ec2_instance_profile.name
 
   tags = {
     Name = "goobi-access-host"

--- a/infrastructure/prod/iam_policy_document.tf
+++ b/infrastructure/prod/iam_policy_document.tf
@@ -1,3 +1,16 @@
+data "aws_iam_policy_document" "assume_ec2_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
 data "aws_iam_policy_document" "alb_logs" {
   statement {
     actions = [

--- a/infrastructure/prod/iam_role_policy.tf
+++ b/infrastructure/prod/iam_role_policy.tf
@@ -1,3 +1,22 @@
+# EC2 Instance Role Policies for bastion hosts
+
+resource "aws_iam_role" "ec2_role" {
+  name = "${local.environment_name}-ec2_role"
+  assume_role_policy = data.aws_iam_policy_document.assume_ec2_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_managed_instance_core" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2_instance_profile" {
+  name = "${local.environment_name}-access_host_instance_profile"
+  role = aws_iam_role.ec2_role.name
+}
+
+# ECS Task Role Policies
+
 resource "aws_iam_role_policy" "ecs_goobi_s3_config_read" {
   role   = module.goobi.task_role
   policy = data.aws_iam_policy_document.s3_read_workflow-configuration.json

--- a/infrastructure/staging/ec2_host.tf
+++ b/infrastructure/staging/ec2_host.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "access_host" {
   ]
   subnet_id                   = element(module.network.public_subnets, 0)
   associate_public_ip_address = true
-  #   user_data = 
+  iam_instance_profile        = aws_iam_instance_profile.ec2_instance_profile.name
 
   tags = {
     Name = "goobi-access-host-staging"

--- a/infrastructure/staging/iam_policy_document.tf
+++ b/infrastructure/staging/iam_policy_document.tf
@@ -1,3 +1,16 @@
+data "aws_iam_policy_document" "assume_ec2_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
 data "aws_iam_policy_document" "alb_logs" {
   statement {
     actions = [

--- a/infrastructure/staging/iam_role_policy.tf
+++ b/infrastructure/staging/iam_role_policy.tf
@@ -1,3 +1,22 @@
+# EC2 Instance Role Policies for bastion hosts
+
+resource "aws_iam_role" "ec2_role" {
+  name = "${local.environment_name}-ec2_role"
+  assume_role_policy = data.aws_iam_policy_document.assume_ec2_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_managed_instance_core" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2_instance_profile" {
+  name = "${local.environment_name}-access_host_instance_profile"
+  role = aws_iam_role.ec2_role.name
+}
+
+# ECS Task Role Policies
+
 resource "aws_iam_role_policy" "ecs_goobi_s3_config_read" {
   role   = module.goobi.task_role
   policy = data.aws_iam_policy_document.s3_read_workflow-configuration.json


### PR DESCRIPTION
## What does this change?

Part of https://github.com/wellcomecollection/platform/issues/6045

Adds the [AmazonSSMManagedInstanceCore](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html) managed policy to EC2 instances so they report stats without error.

## How to test

Log into the EC2 instances using SSH, ensure that ssm agent is running without error.

`sudo systemctl status amazon-ssm-agent`

## How can we measure success?

EC2 instances run SSM agent on startup.

## Have we considered potential risks?

Risks should be minimal, this improves security for our instances by increasing visibility.
